### PR TITLE
feat: 유기동물 리스트 클릭 시 디테일 팝업창 생성

### DIFF
--- a/src/components/AnimalItem.js
+++ b/src/components/AnimalItem.js
@@ -10,7 +10,6 @@ const Container = styled.div`
   height: 250px;
   background-color: ${(props) =>
     props.IsRecruiting === "공고중" ? "rgb(251, 223, 169)" : "rgba(128, 128, 128, 0.2)"};
-  margin-right: 30px;
 `;
 
 const Box = styled.div`
@@ -59,29 +58,29 @@ const DogInfo = styled.div`
 const DogInfoDetail = styled.div`
 `;
 
-function AnimalList({ IsRecruiting, Gender, IsLike, Kind, RegisterDate, Location, RescuePlace }) {
+function AnimalItem({item, onClick}) {
+
+  const {IsRecruiting, Gender, isLike, Kind, RegisterDate, Location, RescuePlace} = item;
   return (
-    <Container IsRecruiting={IsRecruiting}>
+    <Container IsRecruiting={IsRecruiting} onClick={onClick}>
       <Box>
         <HeaderLeft>
           <RecruitState IsRecruiting={IsRecruiting}>{IsRecruiting}</RecruitState>
           <AnimalGender>{Gender}</AnimalGender>
         </HeaderLeft>
-        <LikeIcon size='2x' 
-        icon={IsLike ? solidHeart : regularHeart}
-        IsLike={IsLike}></LikeIcon>
+        <LikeIcon size='2x' icon={isLike ? solidHeart : regularHeart}></LikeIcon>
       </Box>
       <Box>
         <DogImage src={dogImage}></DogImage>
         <DogInfo>
           <DogInfoDetail>품종 : {Kind}</DogInfoDetail>
           <DogInfoDetail>등록일 : {RegisterDate}</DogInfoDetail>
-          <DogInfoDetail>지역 : {Location}</DogInfoDetail>
-          <DogInfoDetail>구조장소 : {RescuePlace}</DogInfoDetail>
+          <DogInfoDetail>지역 : {Location.slice(0,10)}</DogInfoDetail>
+          <DogInfoDetail>구조장소 : {RescuePlace.length < 30 ? RescuePlace : RescuePlace.slice(0,27) + '...'}</DogInfoDetail>
         </DogInfo>
       </Box>
     </Container>
   );
 }
 
-export default AnimalList;
+export default AnimalItem;

--- a/src/components/AnimalPopup.js
+++ b/src/components/AnimalPopup.js
@@ -1,0 +1,237 @@
+import React, { Component, useState, useEffect } from "react";
+import styled, { keyframes } from "styled-components";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faRectangleXmark as closeBtn } from "@fortawesome/free-solid-svg-icons";
+import { faHeart as regularHeart } from "@fortawesome/free-regular-svg-icons";
+import { faHeart as solidHeart } from "@fortawesome/free-solid-svg-icons";
+import dogImage from "../images/dog2.jpeg";
+
+const fadeIn = keyframes`
+  from {
+    opacity: 0
+  }
+  to {
+    opacity: 1
+  }
+`;
+
+const slideUp = keyframes`
+  /* from {
+    transform: translateY(100px);
+  }
+  to {
+    transform: translateY(0px);
+  } */
+`;
+
+const DarkBackground = styled.div`
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.3);
+
+  animation-duration: 0.25s;
+  animation-timing-function: ease-out;
+  animation-name: ${slideUp};
+  animation-fill-mode: forwards;
+`;
+
+const DialogBlock = styled.div`
+  width: 500px;
+  height: 700px;
+  padding: 5px;
+  background: white;
+  border-radius: 2px;
+  border: solid;
+  border-color: orange;
+  border-width: 10px;
+  font-size: 15px;
+`;
+
+const Body = styled.div`
+  width: 80%;
+  margin-left: auto;
+  margin-right: auto;
+`;
+
+const TextBox = styled.div`
+  width: 100%;
+`;
+
+const Header = styled.div`
+  width: 100%;
+  height: 50px;
+  margin-bottom: 30px;
+`;
+
+const CloseBtn = styled(FontAwesomeIcon)`
+  width: 50px;
+  height: 50px;
+  float: right;
+`;
+
+const ImageBox = styled.div`
+  width: fit-content;
+  position: relative;
+`;
+
+const DogImage = styled.img`
+  width: 100%;
+  height: 35%;
+`;
+
+const RecruiteState = styled.div`
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  width: 75px;
+  height: 30px;
+  line-height: 30px;
+  border-radius: 10%;
+  background-color: ${(props) =>
+    props.IsRecruiting === "공고중" ? "orange" : "grey"};
+  color: white;
+`;
+
+const ImageBottomBox = styled.div`
+  height: fit-content;
+  display: flex;
+  margin-left: auto;
+  margin-right: auto;
+  justify-content: space-between;
+  margin-top: 15px;
+`;
+
+const DogKind = styled.div`
+  padding: 3px;
+  background-color: rgba(255, 166, 0, 0.3);
+`;
+
+const DogInfoText = styled.div`
+  text-align: left;
+`;
+
+const DogInfoTextBox = styled.div`
+  display: flex;
+  margin-top: 5px;
+  text-align: left;
+`;
+
+const Divider = styled.div`
+  width: 100%;
+  height: 1px;
+  margin-top: 20px;
+  margin-bottom: 20px;
+  background-color: rgb(0, 0, 0, 0.3);
+`;
+
+const LikeIcon = styled(FontAwesomeIcon)`
+  float: right;
+`;
+
+function AnimalPopup({ onClose, visible }) {
+  const [animate, setAnimate] = useState(false);
+  const [localVisible, setLocalVisible] = useState(visible);
+
+  useEffect(() => {
+    // visible 값이 true -> false 가 되는 것을 감지
+    if (localVisible && !visible) {
+      setAnimate(true);
+      setTimeout(() => setAnimate(false), 250);
+    }
+    setLocalVisible(visible);
+  }, [localVisible, visible]);
+
+  if (!animate && !localVisible) return null;
+
+  const IsRecruiting = "공고중",
+    KeyNumber = "경남-창원시-2022-00107",
+    PreviewInfo = "암컷(중성화 X) / 흰색 + 크림색 / 3(kg)",
+    NoticePeriod = "2022-03-11 ~ 2022-03-19",
+    SpecialFeature = "L-3-1-8 흰색 + 크림색",
+    ProtectionCenter = "창원유기동물보호소(Tel: 055-225-5701)",
+    ManageCenter = "경상남도 창원시 의창성산구청 (Tel:123-345-2324)",
+    Gender = "수컷(중성화O)",
+    isLike = true,
+    Kind = "[개] 푸들",
+    RegisterDate = "2022-04-01",
+    Location = "전남 화순",
+    RescuePlace = "전라남도 화순군 화순읍 부영 6차 아파트";
+  return (
+    <DarkBackground>
+      <DialogBlock>
+        <Header>
+          <CloseBtn icon={closeBtn} onClick={onClose}></CloseBtn>
+        </Header>
+        <Body>
+          <ImageBox>
+            <DogImage src={dogImage}></DogImage>
+            <RecruiteState IsRecruiting={IsRecruiting}>공고중</RecruiteState>
+          </ImageBox>
+          <TextBox>
+            <ImageBottomBox>
+              <DogKind>[개] 포메라니안</DogKind>
+              <LikeIcon
+                size="2x"
+                icon={isLike ? solidHeart : regularHeart}
+              ></LikeIcon>
+            </ImageBottomBox>
+            <DogInfoText>{PreviewInfo}</DogInfoText>
+
+            <Divider></Divider>
+            <DogInfoTextBox>
+              <DogInfoText>공고번호 : &nbsp;&nbsp;</DogInfoText>{" "}
+              <DogInfoText
+                style={{
+                  color: "goldenrod",
+                }}
+              >
+                {KeyNumber}
+              </DogInfoText>
+            </DogInfoTextBox>
+            <DogInfoTextBox>
+              <DogInfoText>공고기간 : &nbsp;&nbsp;</DogInfoText>{" "}
+              <DogInfoText>{NoticePeriod}</DogInfoText>
+            </DogInfoTextBox>
+            <DogInfoTextBox>
+              <DogInfoText>발견장소 : &nbsp;&nbsp;</DogInfoText>{" "}
+              <DogInfoText>{RescuePlace}</DogInfoText>
+            </DogInfoTextBox>
+            <DogInfoTextBox>
+              <DogInfoText>특이사항 : &nbsp;&nbsp;</DogInfoText>{" "}
+              <DogInfoText>{SpecialFeature}</DogInfoText>
+            </DogInfoTextBox>
+            <DogInfoTextBox>
+              <DogInfoText>보호센터 : &nbsp;&nbsp;</DogInfoText>{" "}
+              <DogInfoText>{ProtectionCenter}</DogInfoText>
+            </DogInfoTextBox>
+            <DogInfoTextBox>
+              <DogInfoText>담당센터 : &nbsp;&nbsp;</DogInfoText>{" "}
+              <DogInfoText>{ManageCenter}</DogInfoText>
+            </DogInfoTextBox>
+
+            <Divider></Divider>
+            <DogInfoTextBox>
+              <DogInfoText>바로가기 : &nbsp;&nbsp;</DogInfoText>{" "}
+              <DogInfoText
+                style={{
+                  textDecoration: "underline",
+                  color: "goldenrod",
+                }}
+              >
+                보호소 바로가기 링크
+              </DogInfoText>
+            </DogInfoTextBox>
+          </TextBox>
+        </Body>
+      </DialogBlock>
+    </DarkBackground>
+  );
+}
+
+export default AnimalPopup;

--- a/src/pages/AbandonedAnimal.js
+++ b/src/pages/AbandonedAnimal.js
@@ -1,15 +1,16 @@
-import React, { Component } from "react";
+import React, { Component, useState } from "react";
 import OptionTab from "../components/OptionTab";
-import AnimalList from "../components/AnimalList";
+import AnimalItem from "../components/AnimalItem";
 import styled from "styled-components";
+import AnimalPopup from "../components/AnimalPopup";
 
 const Container = styled.div`
-  width: 1200px;
+  width: fit-content;
   margin-left: auto;
   margin-right: auto;
-  padding-left: 80px;
-  display: flex;
-  margin-bottom: 30px;
+  display: grid;
+  grid-gap: 30px;
+  grid-template-columns: 1fr 1fr 1fr;
 `;
 
 const Body = styled.div`
@@ -17,6 +18,48 @@ const Body = styled.div`
 `;
 
 function AbandonedAnimal() {
+  const data = [
+    {
+      IsRecruiting: "공고중",
+      Gender: "수컷(중성화O)",
+      isLike: true,
+      Kind: "[개] 푸들",
+      RegisterDate: "2022-04-01",
+      Location: "전남 화순",
+      RescuePlace: "전라남도 화순군 화순읍 부영 6차 아파트",
+    },
+    {
+      IsRecruiting: "완료",
+      Gender: "암컷(중성화O)",
+      isLike: false,
+      Kind: "[개] 비숑",
+      RegisterDate: "2022-04-01",
+      Location: "서울 강서구",
+      RescuePlace: "서울 강서구 화순읍 부영 6차 아파트",
+    },
+    {
+      IsRecruiting: "공고중",
+      Gender: "암컷(중성화X)",
+      isLike: true,
+      Kind: "[개] 말티즈",
+      RegisterDate: "2022-04-01",
+      Location: "부산 해운대구",
+      RescuePlace: "부산 해운대구 화순읍 부영 6차 아파트",
+    },
+  ];
+
+  const [dialog, setDialog] = useState(false);
+  const [animals, setAnimals] = useState(data);
+
+  const onClose = () => {
+    setDialog(false);
+  };
+
+  const onClick = () => {
+    console.log("클릭");
+    setDialog(true);
+  };
+
   return (
     <div>
       <OptionTab
@@ -26,61 +69,22 @@ function AbandonedAnimal() {
       ></OptionTab>
       <Body>
         <Container>
-          <AnimalList
-            IsRecruiting={"공고중"}
-            Gender={"암컷(중성화O)"}
-            IsLike
-            Kind={"[개] 푸들"}
-            RegisterDate="2022-04-01"
-            Location="전남 화순"
-            RescuePlace={"전라남도 화순군 화순읍 부영 6차 아파트"}
-          ></AnimalList>
-          <AnimalList
-            IsRecruiting={"공고중"}
-            Gender={"암컷(중성화O)"}
-            Kind={"[개] 푸들"}
-            RegisterDate="2022-04-01"
-            Location="전남 화순"
-            RescuePlace={"전라남도 화순군 화순읍 부영 6차 아파트"}
-          ></AnimalList>
-          <AnimalList
-            IsRecruiting={"완료"}
-            Gender={"암컷(중성화O)"}
-            IsLike
-            Kind={"[개] 푸들"}
-            RegisterDate="2022-04-01"
-            Location="전남 화순"
-            RescuePlace={"전라남도 화순군 화순읍 부영 6차 아파트"}
-          ></AnimalList>
-        </Container>
-        <Container>
-          <AnimalList
-            IsRecruiting={"완료"}
-            Gender={"암컷(중성화O)"}
-            Kind={"[개] 푸들"}
-            RegisterDate="2022-04-01"
-            Location="전남 화순"
-            RescuePlace={"전라남도 화순군 화순읍 부영 6차 아파트"}
-          ></AnimalList>
-          <AnimalList
-            IsRecruiting={"완료"}
-            Gender={"암컷(중성화O)"}
-            Kind={"[개] 푸들"}
-            RegisterDate="2022-04-01"
-            Location="전남 화순"
-            RescuePlace={"전라남도 화순군 화순읍 부영 6차 아파트"}
-          ></AnimalList>
-          <AnimalList
-            IsRecruiting={"공고중"}
-            Gender={"암컷(중성화O)"}
-            IsLike
-            Kind={"[개] 푸들"}
-            RegisterDate="2022-04-01"
-            Location="전남 화순"
-            RescuePlace={"전라남도 화순군 화순읍 부영 6차 아파트"}
-          ></AnimalList>
+          <AnimalItem item={animals[0]} onClick={onClick}></AnimalItem>
+          <AnimalItem item={animals[1]} onClick={onClick}></AnimalItem>
+          <AnimalItem item={animals[1]} onClick={onClick}></AnimalItem>
+          <AnimalItem item={animals[2]} onClick={onClick}></AnimalItem>
+          <AnimalItem item={animals[0]} onClick={onClick}></AnimalItem>
+          <AnimalItem item={animals[0]} onClick={onClick}></AnimalItem>
+          <AnimalItem item={animals[1]} onClick={onClick}></AnimalItem>
+          <AnimalItem item={animals[2]} onClick={onClick}></AnimalItem>
+          <AnimalItem item={animals[0]} onClick={onClick}></AnimalItem>
+          {/* {animals.map((item) => {
+            // console.log(item);
+            <AnimalItem item={item}></AnimalItem>;
+          })} */}
         </Container>
       </Body>
+      <AnimalPopup onClose={onClose} visible={dialog}></AnimalPopup>
     </div>
   );
 }

--- a/src/styles/BoardBox.module.css
+++ b/src/styles/BoardBox.module.css
@@ -64,7 +64,6 @@
 }
 
 .box__photo {
-
 }
 
 .photo {

--- a/src/styles/Header.css
+++ b/src/styles/Header.css
@@ -25,8 +25,8 @@
   top: 15%;
   left: 50%;
   color: rgb(243, 156, 18);
-  font-weight: 700;
-  font-size: x-large;
+  font-weight: 800;
+  font-size: 30px;
 }
 
 .Container {
@@ -39,8 +39,8 @@
 
 .Container-Text {
   padding-left: 10px;
-  font-size: 1rem;
-  font-weight: 1000;
+  font-size: 23px;
+  font-weight: 800;
   display: inline-block;
   color: rgb(243, 156, 18);
 }


### PR DESCRIPTION
유기동물 리스트를 grid layout 으로 생성
유기동물 리스트 컴포넌트의 props 에 dummy data 를 object 로 보내줌
데이터 값에 따라 <공고중,완료> / <하트 좋아요> / 나머지 text 연동됨
팝업창 띄우면 뒷배경 어둡게 하기
아직 팝업창 props 로 dummy data 넘겨주는 것은 구현X